### PR TITLE
Rework query arg

### DIFF
--- a/ext/src/execution/engine.rs
+++ b/ext/src/execution/engine.rs
@@ -22,6 +22,7 @@ use bluejay_core::{
 };
 use bluejay_parser::ast::executable::{ExecutableDocument, Field, OperationDefinition, Selection};
 use bluejay_parser::ast::{Directive, VariableArguments, VariableValue};
+use bluejay_parser::error::SpanToLocation;
 use bluejay_validator::Path;
 use indexmap::IndexMap;
 use magnus::{Error, RArray, RHash, Value, QNIL};
@@ -200,7 +201,12 @@ impl<'a> Engine<'a> {
     }
 
     fn execution_result(value: Value, errors: Vec<ExecutionError>, query: &str) -> ExecutionResult {
-        ExecutionResult::new(value, errors)
+        let span_to_location = SpanToLocation::new(query);
+        let errors_with_span_to_location: Vec<(ExecutionError, SpanToLocation)> = errors
+            .iter()
+            .map(|err| (err.clone(), span_to_location))
+            .collect();
+        ExecutionResult::new(value, errors_with_span_to_location)
     }
 
     fn execute_operation(

--- a/ext/src/execution/engine.rs
+++ b/ext/src/execution/engine.rs
@@ -201,11 +201,16 @@ impl<'a> Engine<'a> {
     }
 
     fn execution_result(value: Value, errors: Vec<ExecutionError>, query: &str) -> ExecutionResult {
-        let span_to_location = SpanToLocation::new(query);
-        let errors_with_span_to_location: Vec<(ExecutionError, SpanToLocation)> = errors
-            .iter()
-            .map(|err| (err.clone(), span_to_location))
-            .collect();
+        let errors_with_span_to_location: Vec<(ExecutionError, SpanToLocation)> =
+            if errors.is_empty() {
+                vec![]
+            } else {
+                let span_to_location = SpanToLocation::new(query);
+                errors
+                    .iter()
+                    .map(|err| (err.clone(), span_to_location))
+                    .collect()
+            };
         ExecutionResult::new(value, errors_with_span_to_location)
     }
 

--- a/ext/src/execution/execution_error.rs
+++ b/ext/src/execution/execution_error.rs
@@ -19,7 +19,6 @@ pub enum ExecutionError<'a> {
     FieldError {
         error: FieldError,
         path: Path<'a>,
-        query: &'a str,
         fields: Vec<&'a bluejay_parser::ast::executable::Field<'a>>,
     },
 }
@@ -33,7 +32,7 @@ impl<'a> From<ExecutionError<'a>> for RubyExecutionError {
             ExecutionError::ApplicationError(error) => Self::new(format!("Internal error: {error}"), None, None),
             ExecutionError::CoercionError(error) =>  error.into(),
             ExecutionError::ParseError(error) => Self::new(error.message().to_owned(), None, None),
-            ExecutionError::FieldError { error, path, fields, query } => {
+            ExecutionError::FieldError { error, path, fields } => {
                 let get_location = |field: &&bluejay_parser::ast::executable::Field<'_>| {
                     let span = field.span();
                     let (line, column) = SpanToLocation::new(query).convert(span).unwrap();

--- a/ext/src/execution/execution_error.rs
+++ b/ext/src/execution/execution_error.rs
@@ -23,9 +23,10 @@ pub enum ExecutionError<'a> {
     },
 }
 
-impl<'a> From<ExecutionError<'a>> for RubyExecutionError {
-    fn from(val: ExecutionError<'a>) -> Self {
-        match val {
+impl<'a> From<(ExecutionError<'a>, SpanToLocation<'a>)> for RubyExecutionError {
+    fn from(val: (ExecutionError<'a>, SpanToLocation<'a>)) -> Self {
+        let (execution_error, span_to_location) = val;
+        match execution_error {
             ExecutionError::NoOperationWithName { name } => Self::new(format!("No operation definition named `{name}`"), None, None),
             ExecutionError::CannotUseAnonymousOperation => Self::new("Operation name is required when document does not contain exactly 1 operation definition", None, None),
             ExecutionError::RequiredVariableMissingValue { name } => Self::new(format!("No value was provided for required variable `${name}`"), None, None),
@@ -35,7 +36,7 @@ impl<'a> From<ExecutionError<'a>> for RubyExecutionError {
             ExecutionError::FieldError { error, path, fields } => {
                 let get_location = |field: &&bluejay_parser::ast::executable::Field<'_>| {
                     let span = field.span();
-                    let (line, column) = SpanToLocation::new(query).convert(span).unwrap();
+                    let (line, column) = span_to_location.convert(span).unwrap();
                     ErrorLocation::new(line, column)
                 };
 


### PR DESCRIPTION
This gives an error: 

```
   Compiling bluejay-rb v0.1.0 (/Users/rmosolgo/code/bluejay-rb/ext)
error[E0277]: a value of type `Vec<(execution::execution_error::ExecutionError<'_>, SpanToLocation<'_>)>` cannot be built from an iterator over elements of type `(&execution::execution_error::ExecutionError<'_>, SpanToLocation<'_>)`
    --> ext/src/execution/engine.rs:212:22
     |
212  |                     .collect()
     |                      ^^^^^^^ value of type `Vec<(execution::execution_error::ExecutionError<'_>, SpanToLocation<'_>)>` cannot be built from `std::iter::Iterator<Item=(&execution::execution_error::ExecutionError<'_>, SpanToLocation<'_>)>`
     |
     = help: the trait `FromIterator<(&execution::execution_error::ExecutionError<'_>, SpanToLocation<'_>)>` is not implemented for `Vec<(execution::execution_error::ExecutionError<'_>, SpanToLocation<'_>)>`
     = help: the trait `FromIterator<T>` is implemented for `Vec<T>`
note: the method call chain might not have had the expected associated types
    --> ext/src/execution/engine.rs:211:22
     |
209  |                 errors
     |                 ------ this expression has type `Vec<ExecutionError<'_>>`
210  |                     .iter()
     |                      ------ `Iterator::Item` is `&ExecutionError<'_>` here
211  |                     .map(|err| (err.clone(), span_to_location))
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Iterator::Item` changed to `(&ExecutionError<'_>, SpanToLocation<'_>)` here
note: required by a bound in `collect`
    --> /Users/rmosolgo/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:1891:19
     |
1891 |     fn collect<B: FromIterator<Self::Item>>(self) -> B
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Iterator::collect`
```